### PR TITLE
Disallow inferred equivalencies when reasoning.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -66,7 +66,7 @@ all: odkversion all_imports patterns all_main all_subsets sparql_test all_report
 
 .PHONY: test
 test: odkversion sparql_test all_reports 
-	$(ROBOT) reason --input $(SRC) --reasoner ELK  --equivalent-classes-allowed asserted-only --exclude-tautologies structural --output test.owl && rm test.owl && echo "Success"
+	$(ROBOT) reason --input $(SRC) --reasoner ELK  --equivalent-classes-allowed none --exclude-tautologies structural --output test.owl && rm test.owl && echo "Success"
 
 .PHONY: odkversion
 odkversion:
@@ -498,7 +498,7 @@ $(ONT)-base.owl: $(SRC) $(OTHER_SRC)
 # Full: The full artefacts with imports merged, reasoned
 $(ONT)-full.owl: $(SRC) $(OTHER_SRC)
 	$(ROBOT) merge --input $< \
-		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
+		reason --reasoner ELK --equivalent-classes-allowed none --exclude-tautologies structural \
 		relax \
 		reduce -r ELK \
 		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) --annotation oboInOwl:date "$(OBODATE)" --output $@.tmp.owl && mv $@.tmp.owl $@
@@ -513,7 +513,7 @@ $(ONT)-non-classified.owl: $(SRC) $(OTHER_SRC)
 
 $(ONT)-simple.owl: $(SRC) $(OTHER_SRC) $(SIMPLESEED)
 	$(ROBOT) merge --input $< $(patsubst %, -i %, $(OTHER_SRC)) \
-		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
+		reason --reasoner ELK --equivalent-classes-allowed none --exclude-tautologies structural \
 		relax \
 		remove --axioms equivalent \
 		relax \

--- a/src/ontology/fbdv-odk.yaml
+++ b/src/ontology/fbdv-odk.yaml
@@ -24,5 +24,5 @@ import_group:
     - id: ro
 edit_format: obo
 robot_java_args: '-Xmx8G'
-allow_equivalents: asserted-only
+allow_equivalents: none
 release_date: TRUE

--- a/src/ontology/fbdv.Makefile
+++ b/src/ontology/fbdv.Makefile
@@ -175,5 +175,5 @@ obo_qc_%:
 obo_qc: obo_qc_$(ONT).obo obo_qc_$(ONT).owl
 
 flybase_qc: odkversion obo_qc
-	$(ROBOT) reason --input $(ONT)-full.owl --reasoner ELK  --equivalent-classes-allowed asserted-only --output test.owl && rm test.owl && echo "Success"
+	$(ROBOT) reason --input $(ONT)-full.owl --reasoner ELK  --equivalent-classes-allowed none --output test.owl && rm test.owl && echo "Success"
 


### PR DESCRIPTION
Make ROBOT fail when the reasoner finds inferred equivalent classes.

As recommended by Chris Mungall ([rationale](https://douroucouli.wordpress.com/2018/09/04/debugging-ontologies-using-owl-reasoning-part-2-unintentional-entailed-equivalence/)) and Nico Matentzoglu on Slack.

As for the other FlyBase ontologies:
- already done for FBbt with FlyBase/drosophila-anatomy-developmental-ontology#1319
- cannot be done for FBcv, it has to remain on `assert-only`
- currently cannot be done for DPO, which has one non-asserted equivalence between `CL:0000003` (`cell`) and `GO:0005623`) (obsolete GO term for `cell`); that equivalence is brought in by CARO, whose term `CARO:0000013` still refers to `GO:0005623` even though it has been obsoleted (obophenotype/caro#23); if we can get that fixed in CARO, then we should be able to switch the `allow_equivalents` setting in DPO from `all` to `assert-only`.