### PR TITLE
Add 'day 70 of adulthood'

### DIFF
--- a/src/ontology/fbdv-edit.obo
+++ b/src/ontology/fbdv-edit.obo
@@ -2031,6 +2031,116 @@ relationship: FBdv:00018001 FBdv:00005321 ! substage of extended germ band stage
 relationship: RO:0002087 FBdv:00005317 ! immediately preceded by gastrula stage
 relationship: RO:0002087 FBdv:00005322 ! immediately preceded by embryonic stage 8
 
+[Term]
+id: FBdv:0010001
+name: day 61 of adulthood
+def: "61st day after eclosion." [FBC:DPG]
+comment: Temporal ordering number - 1410.
+is_a: FBdv:00007014 ! adult age in days
+relationship: FBdv:00018001 FBdv:00005369 ! substage of adult stage
+relationship: RO:0002087 FBdv:00007135 ! immediately preceded by day 60 of adulthood
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-01-15T17:54:59Z" xsd:dateTime
+
+[Term]
+id: FBdv:0010002
+name: day 62 of adulthood
+def: "62nd day after eclosion." [FBC:DPG]
+comment: Temporal ordering number - 1420.
+is_a: FBdv:00007014 ! adult age in days
+relationship: FBdv:00018001 FBdv:00005369 ! substage of adult stage
+relationship: RO:0002087 FBdv:0010001 ! immediately preceded by day 61 of adulthood
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-01-15T17:54:59Z" xsd:dateTime
+
+[Term]
+id: FBdv:0010003
+name: day 63 of adulthood
+def: "63rd day after eclosion." [FBC:DPG]
+comment: Temporal ordering number - 1430.
+is_a: FBdv:00007014 ! adult age in days
+relationship: FBdv:00018001 FBdv:00005369 ! substage of adult stage
+relationship: RO:0002087 FBdv:0010002 ! immediately preceded by day 62 of adulthood
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-01-15T17:54:59Z" xsd:dateTime
+
+[Term]
+id: FBdv:0010004
+name: day 64 of adulthood
+def: "64th day after eclosion." [FBC:DPG]
+comment: Temporal ordering number - 1440.
+is_a: FBdv:00007014 ! adult age in days
+relationship: FBdv:00018001 FBdv:00005369 ! substage of adult stage
+relationship: RO:0002087 FBdv:0010003 ! immediately preceded by day 63 of adulthood
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-01-15T17:54:59Z" xsd:dateTime
+
+[Term]
+id: FBdv:0010005
+name: day 65 of adulthood
+def: "65th day after eclosion." [FBC:DPG]
+comment: Temporal ordering number - 1450.
+is_a: FBdv:00007014 ! adult age in days
+relationship: FBdv:00018001 FBdv:00005369 ! substage of adult stage
+relationship: RO:0002087 FBdv:0010004 ! immediately preceded by day 64 of adulthood
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-01-15T17:54:59Z" xsd:dateTime
+
+[Term]
+id: FBdv:0010006
+name: day 66 of adulthood
+def: "66th day after eclosion." [FBC:DPG]
+comment: Temporal ordering number - 1460.
+is_a: FBdv:00007014 ! adult age in days
+relationship: FBdv:00018001 FBdv:00005369 ! substage of adult stage
+relationship: RO:0002087 FBdv:0010005 ! immediately preceded by day 65 of adulthood
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-01-15T17:54:59Z" xsd:dateTime
+
+[Term]
+id: FBdv:0010007
+name: day 67 of adulthood
+def: "67th day after eclosion." [FBC:DPG]
+comment: Temporal ordering number - 1470.
+is_a: FBdv:00007014 ! adult age in days
+relationship: FBdv:00018001 FBdv:00005369 ! substage of adult stage
+relationship: RO:0002087 FBdv:0010006 ! immediately preceded by day 66 of adulthood
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-01-15T17:54:59Z" xsd:dateTime
+
+[Term]
+id: FBdv:0010008
+name: day 68 of adulthood
+def: "68th day after eclosion." [FBC:DPG]
+comment: Temporal ordering number - 1480.
+is_a: FBdv:00007014 ! adult age in days
+relationship: FBdv:00018001 FBdv:00005369 ! substage of adult stage
+relationship: RO:0002087 FBdv:0010007 ! immediately preceded by day 67 of adulthood
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-01-15T17:54:59Z" xsd:dateTime
+
+[Term]
+id: FBdv:0010009
+name: day 69 of adulthood
+def: "69th day after eclosion." [FBC:DPG]
+comment: Temporal ordering number - 1490.
+is_a: FBdv:00007014 ! adult age in days
+relationship: FBdv:00018001 FBdv:00005369 ! substage of adult stage
+relationship: RO:0002087 FBdv:0010008 ! immediately preceded by day 68 of adulthood
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-01-15T17:54:59Z" xsd:dateTime
+
+[Term]
+id: FBdv:0010010
+name: day 70 of adulthood
+def: "70th day after eclosion." [FBC:DPG]
+comment: Temporal ordering number - 1500.
+is_a: FBdv:00007014 ! adult age in days
+relationship: FBdv:00018001 FBdv:00005369 ! substage of adult stage
+relationship: RO:0002087 FBdv:0010009 ! immediately preceded by day 69 of adulthood
+property_value: http://purl.org/dc/terms/contributor https://orcid.org/0000-0002-6095-8718
+property_value: http://purl.org/dc/terms/date "2024-01-15T17:54:59Z" xsd:dateTime
+
 [Typedef]
 id: FBdv:00018001
 name: substage of

--- a/src/ontology/fbdv-idranges.owl
+++ b/src/ontology/fbdv-idranges.owl
@@ -46,6 +46,15 @@ Datatype: idrange:2
     
     EquivalentTo: 
         xsd:integer[>= 0007000 , <= 0010000]
+
+
+Datatype: idrange:3
+
+    Annotations:
+        allocatedto: "dpg44"
+
+    EquivalentTo:
+        xsd:integer[>= 0010001 , <= 0011000]
     
     
 Datatype: xsd:integer


### PR DESCRIPTION
This PR adds more subclasses of 'adult age in days' for flies aged between 61 and 70 days. This will be needed for the upcoming Aging Fly Cell Atlas scRNAseq dataset, where some of the samples come from 70-days old flies.

closes #89 